### PR TITLE
Add func to get described Package IDs for a document

### DIFF
--- a/spdxlib/described_elements.go
+++ b/spdxlib/described_elements.go
@@ -1,0 +1,75 @@
+// Package spdxlib contains convenience and utility functions for working
+// with an SPDX document that has already been created in memory.
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+package spdxlib
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/spdx/tools-golang/spdx"
+)
+
+// GetDescribedPackageIDs2_1 returns a slice of ElementIDs for all Packages
+// in this Document that it "describes," according to SPDX rules:
+// - If the document has only one Package, its ID is returned.
+// - If the document has 2+ Packages, it returns the IDs of those that have
+//   a DESCRIBES (or DESCRIBED_BY) relationship to this DOCUMENT. If no
+// -
+func GetDescribedPackageIDs2_1(doc *spdx.Document2_1) ([]spdx.ElementID, error) {
+	// if nil Packages map or zero packages in it, return empty slice
+	if doc.Packages == nil {
+		return nil, fmt.Errorf("Packages map is nil")
+	}
+	if len(doc.Packages) == 0 {
+		return nil, fmt.Errorf("no Packages in Document")
+	}
+	if len(doc.Packages) == 1 {
+		// get first (only) one and return its ID
+		for i := range doc.Packages {
+			return []spdx.ElementID{i}, nil
+		}
+	}
+
+	// two or more packages, so we need to go through the relationships,
+	// find DESCRIBES or DESCRIBED_BY for this DOCUMENT, verify they are
+	// valid IDs in this document's packages, and return them
+	if doc.Relationships == nil {
+		return nil, fmt.Errorf("multiple Packages in Document but Relationships slice is nil")
+	}
+	// collect IDs as strings so we can sort them easily
+	eIDStrs := []string{}
+	for _, rln := range doc.Relationships {
+		if rln.Relationship == "DESCRIBES" && rln.RefA == spdx.MakeDocElementID("", "DOCUMENT") {
+			// confirm RefB is actually a package in this document
+			if _, ok := doc.Packages[rln.RefB.ElementRefID]; !ok {
+				// if it's an unpackaged file, that's valid (no error) but don't return it
+				if _, ok2 := doc.UnpackagedFiles[rln.RefB.ElementRefID]; !ok2 {
+					return nil, fmt.Errorf("Document DESCRIBES %s but no such Package or unpackaged File", string(rln.RefB.ElementRefID))
+				}
+			}
+			eIDStrs = append(eIDStrs, string(rln.RefB.ElementRefID))
+		}
+		if rln.Relationship == "DESCRIBED_BY" && rln.RefB == spdx.MakeDocElementID("", "DOCUMENT") {
+			// confirm RefA is actually a package in this document
+			// if it's an unpackaged file, that's valid (no error) but don't return it
+			if _, ok := doc.Packages[rln.RefA.ElementRefID]; !ok {
+				// if it's an unpackaged file, that's valid (no error) but don't return it
+				if _, ok2 := doc.UnpackagedFiles[rln.RefA.ElementRefID]; !ok2 {
+					return nil, fmt.Errorf("%s DESCRIBED_BY Document but no such Package or unpackaged File", string(rln.RefA.ElementRefID))
+				}
+			}
+			eIDStrs = append(eIDStrs, string(rln.RefA.ElementRefID))
+		}
+	}
+	if len(eIDStrs) == 0 {
+		return nil, fmt.Errorf("no DESCRIBES or DESCRIBED_BY relationships found for this Document")
+	}
+	// sort them, convert back to ElementIDs and return
+	sort.Strings(eIDStrs)
+	eIDs := []spdx.ElementID{}
+	for _, eIDStr := range eIDStrs {
+		eIDs = append(eIDs, spdx.ElementID(eIDStr))
+	}
+	return eIDs, nil
+}

--- a/spdxlib/described_elements_test.go
+++ b/spdxlib/described_elements_test.go
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+
+package spdxlib
+
+import (
+	"testing"
+
+	"github.com/spdx/tools-golang/spdx"
+)
+
+func TestCanGetIDsOfDescribedPackages(t *testing.T) {
+	// set up document and some packages and relationships
+	doc := &spdx.Document2_1{
+		CreationInfo: &spdx.CreationInfo2_1{
+			SPDXVersion:    "SPDX-2.1",
+			DataLicense:    "CC0-1.0",
+			SPDXIdentifier: spdx.ElementID("DOCUMENT"),
+		},
+		Packages: map[spdx.ElementID]*spdx.Package2_1{
+			spdx.ElementID("p1"): &spdx.Package2_1{PackageName: "pkg1", PackageSPDXIdentifier: "p1"},
+			spdx.ElementID("p2"): &spdx.Package2_1{PackageName: "pkg2", PackageSPDXIdentifier: "p2"},
+			spdx.ElementID("p3"): &spdx.Package2_1{PackageName: "pkg3", PackageSPDXIdentifier: "p3"},
+			spdx.ElementID("p4"): &spdx.Package2_1{PackageName: "pkg4", PackageSPDXIdentifier: "p4"},
+			spdx.ElementID("p5"): &spdx.Package2_1{PackageName: "pkg5", PackageSPDXIdentifier: "p5"},
+		},
+		Relationships: []*spdx.Relationship2_1{
+			&spdx.Relationship2_1{
+				RefA:         spdx.MakeDocElementID("", "DOCUMENT"),
+				RefB:         spdx.MakeDocElementID("", "p1"),
+				Relationship: "DESCRIBES",
+			},
+			&spdx.Relationship2_1{
+				RefA:         spdx.MakeDocElementID("", "DOCUMENT"),
+				RefB:         spdx.MakeDocElementID("", "p5"),
+				Relationship: "DESCRIBES",
+			},
+			// inverse relationship -- should also get detected
+			&spdx.Relationship2_1{
+				RefA:         spdx.MakeDocElementID("", "p4"),
+				RefB:         spdx.MakeDocElementID("", "DOCUMENT"),
+				Relationship: "DESCRIBED_BY",
+			},
+			// different relationship
+			&spdx.Relationship2_1{
+				RefA:         spdx.MakeDocElementID("", "p1"),
+				RefB:         spdx.MakeDocElementID("", "p2"),
+				Relationship: "DEPENDS_ON",
+			},
+		},
+	}
+
+	// request IDs for DESCRIBES / DESCRIBED_BY relationships
+	describedPkgIDs, err := GetDescribedPackageIDs2_1(doc)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	// should be three of the five IDs, returned in alphabetical order
+	if len(describedPkgIDs) != 3 {
+		t.Fatalf("expected %d packages, got %d", 3, len(describedPkgIDs))
+	}
+	if describedPkgIDs[0] != spdx.ElementID("p1") {
+		t.Errorf("expected %v, got %v", spdx.ElementID("p1"), describedPkgIDs[0])
+	}
+	if describedPkgIDs[1] != spdx.ElementID("p4") {
+		t.Errorf("expected %v, got %v", spdx.ElementID("p4"), describedPkgIDs[1])
+	}
+	if describedPkgIDs[2] != spdx.ElementID("p5") {
+		t.Errorf("expected %v, got %v", spdx.ElementID("p5"), describedPkgIDs[2])
+	}
+}
+
+func TestGetDescribedPackagesReturnsSinglePackageIfOnlyOne(t *testing.T) {
+	// set up document and one package, but no relationships
+	// b/c only one package
+	doc := &spdx.Document2_1{
+		CreationInfo: &spdx.CreationInfo2_1{
+			SPDXVersion:    "SPDX-2.1",
+			DataLicense:    "CC0-1.0",
+			SPDXIdentifier: spdx.ElementID("DOCUMENT"),
+		},
+		Packages: map[spdx.ElementID]*spdx.Package2_1{
+			spdx.ElementID("p1"): &spdx.Package2_1{PackageName: "pkg1", PackageSPDXIdentifier: "p1"},
+		},
+	}
+
+	// request IDs for DESCRIBES / DESCRIBED_BY relationships
+	describedPkgIDs, err := GetDescribedPackageIDs2_1(doc)
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	// should return the single package
+	if len(describedPkgIDs) != 1 {
+		t.Fatalf("expected %d package, got %d", 1, len(describedPkgIDs))
+	}
+	if describedPkgIDs[0] != spdx.ElementID("p1") {
+		t.Errorf("expected %v, got %v", spdx.ElementID("p1"), describedPkgIDs[0])
+	}
+}
+
+func TestFailsToGetDescribedPackagesIfMoreThanOneWithoutDescribesRelationship(t *testing.T) {
+	// set up document and multiple packages, but no DESCRIBES relationships
+	doc := &spdx.Document2_1{
+		CreationInfo: &spdx.CreationInfo2_1{
+			SPDXVersion:    "SPDX-2.1",
+			DataLicense:    "CC0-1.0",
+			SPDXIdentifier: spdx.ElementID("DOCUMENT"),
+		},
+		Packages: map[spdx.ElementID]*spdx.Package2_1{
+			spdx.ElementID("p1"): &spdx.Package2_1{PackageName: "pkg1", PackageSPDXIdentifier: "p1"},
+			spdx.ElementID("p2"): &spdx.Package2_1{PackageName: "pkg2", PackageSPDXIdentifier: "p2"},
+			spdx.ElementID("p3"): &spdx.Package2_1{PackageName: "pkg3", PackageSPDXIdentifier: "p3"},
+			spdx.ElementID("p4"): &spdx.Package2_1{PackageName: "pkg4", PackageSPDXIdentifier: "p4"},
+			spdx.ElementID("p5"): &spdx.Package2_1{PackageName: "pkg5", PackageSPDXIdentifier: "p5"},
+		},
+		Relationships: []*spdx.Relationship2_1{
+			// different relationship
+			&spdx.Relationship2_1{
+				RefA:         spdx.MakeDocElementID("", "p1"),
+				RefB:         spdx.MakeDocElementID("", "p2"),
+				Relationship: "DEPENDS_ON",
+			},
+		},
+	}
+
+	_, err := GetDescribedPackageIDs2_1(doc)
+	if err == nil {
+		t.Fatalf("expected non-nil error, got nil")
+	}
+}
+
+func TestFailsToGetDescribedPackagesIfMoreThanOneWithNilRelationships(t *testing.T) {
+	// set up document and multiple packages, but no relationships slice
+	doc := &spdx.Document2_1{
+		CreationInfo: &spdx.CreationInfo2_1{
+			SPDXVersion:    "SPDX-2.1",
+			DataLicense:    "CC0-1.0",
+			SPDXIdentifier: spdx.ElementID("DOCUMENT"),
+		},
+		Packages: map[spdx.ElementID]*spdx.Package2_1{
+			spdx.ElementID("p1"): &spdx.Package2_1{PackageName: "pkg1", PackageSPDXIdentifier: "p1"},
+			spdx.ElementID("p2"): &spdx.Package2_1{PackageName: "pkg2", PackageSPDXIdentifier: "p2"},
+		},
+	}
+
+	_, err := GetDescribedPackageIDs2_1(doc)
+	if err == nil {
+		t.Fatalf("expected non-nil error, got nil")
+	}
+}
+
+func TestFailsToGetDescribedPackagesIfZeroPackagesInMap(t *testing.T) {
+	// set up document but no packages
+	doc := &spdx.Document2_1{
+		CreationInfo: &spdx.CreationInfo2_1{
+			SPDXVersion:    "SPDX-2.1",
+			DataLicense:    "CC0-1.0",
+			SPDXIdentifier: spdx.ElementID("DOCUMENT"),
+		},
+		Packages: map[spdx.ElementID]*spdx.Package2_1{},
+	}
+
+	_, err := GetDescribedPackageIDs2_1(doc)
+	if err == nil {
+		t.Fatalf("expected non-nil error, got nil")
+	}
+}
+
+func TestFailsToGetDescribedPackagesIfNilMap(t *testing.T) {
+	// set up document but no packages
+	doc := &spdx.Document2_1{
+		CreationInfo: &spdx.CreationInfo2_1{
+			SPDXVersion:    "SPDX-2.1",
+			DataLicense:    "CC0-1.0",
+			SPDXIdentifier: spdx.ElementID("DOCUMENT"),
+		},
+	}
+
+	_, err := GetDescribedPackageIDs2_1(doc)
+	if err == nil {
+		t.Fatalf("expected non-nil error, got nil")
+	}
+}
+
+func TestFailsToGetDescribedPackagesIfRelationshipForNonexistantPackageID(t *testing.T) {
+	// set up document and multiple packages, but no DESCRIBES relationships
+	doc := &spdx.Document2_1{
+		CreationInfo: &spdx.CreationInfo2_1{
+			SPDXVersion:    "SPDX-2.1",
+			DataLicense:    "CC0-1.0",
+			SPDXIdentifier: spdx.ElementID("DOCUMENT"),
+		},
+		Packages: map[spdx.ElementID]*spdx.Package2_1{
+			spdx.ElementID("p1"): &spdx.Package2_1{PackageName: "pkg1", PackageSPDXIdentifier: "p1"},
+			spdx.ElementID("p2"): &spdx.Package2_1{PackageName: "pkg2", PackageSPDXIdentifier: "p2"},
+		},
+		Relationships: []*spdx.Relationship2_1{
+			// different relationship
+			&spdx.Relationship2_1{
+				RefA:         spdx.MakeDocElementID("", "DOCUMENT"),
+				RefB:         spdx.MakeDocElementID("", "p17"),
+				Relationship: "DESCRIBES",
+			},
+		},
+	}
+
+	_, err := GetDescribedPackageIDs2_1(doc)
+	if err == nil {
+		t.Fatalf("expected non-nil error, got nil")
+	}
+}


### PR DESCRIPTION
Fixes spdx/tools-golang #28 after #24 is addressed

Signed-off-by: Steve Winslow <steve@swinslow.net>